### PR TITLE
Solution: 06 Extract from discriminated union problem

### DIFF
--- a/src/02-unions-and-indexing/06-extract-from-discriminated-union.problem.ts
+++ b/src/02-unions-and-indexing/06-extract-from-discriminated-union.problem.ts
@@ -14,6 +14,6 @@ export type Event =
       event: KeyboardEvent;
     };
 
-type ClickEvent = unknown;
+type ClickEvent = Extract<Event, { type: "click" }>;
 
 type tests = [Expect<Equal<ClickEvent, { type: "click"; event: MouseEvent }>>];


### PR DESCRIPTION
## My Solution

`type ClickEvent = Extract<Event, { type: "click" }>;`

## Explanation

Pretty straightforward, simply just utilizing `Extract` utility type.