### PR TITLE
Solution: 08 Indexed access

### DIFF
--- a/src/02-unions-and-indexing/08-indexed-access.problem.ts
+++ b/src/02-unions-and-indexing/08-indexed-access.problem.ts
@@ -8,11 +8,13 @@ export const fakeDataDefaults = {
   ID: "id",
 };
 
-export type StringType = unknown;
-export type IntType = unknown;
-export type FloatType = unknown;
-export type BooleanType = unknown;
-export type IDType = unknown;
+type FakeDataDefaults = typeof fakeDataDefaults
+
+export type StringType = FakeDataDefaults["String"];
+export type IntType = FakeDataDefaults["Int"];
+export type FloatType = FakeDataDefaults["Float"];
+export type BooleanType = FakeDataDefaults["Boolean"];
+export type IDType = FakeDataDefaults["ID"];
 
 type tests = [
   Expect<Equal<StringType, string>>,


### PR DESCRIPTION
## My Solution
```
type FakeDataDefaults = typeof fakeDataDefaults

export type StringType = FakeDataDefaults["String"];
export type IntType = FakeDataDefaults["Int"];
export type FloatType = FakeDataDefaults["Float"];
export type BooleanType = FakeDataDefaults["Boolean"];
export type IDType = FakeDataDefaults["ID"];
```

## Explanation
1. The first step we transform first `fakeDataDefaults` from value-domain into type-domain by using `typeof`
2. And then we can access every key of `FakeDataDefaults` by using indexed access