### PR TITLE
Solution: 09 Discriminated union to discriminator

### DIFF
--- a/src/02-unions-and-indexing/09-discriminated-union-to-discriminator.problem.ts
+++ b/src/02-unions-and-indexing/09-discriminated-union-to-discriminator.problem.ts
@@ -14,6 +14,6 @@ export type Event =
       event: KeyboardEvent;
     };
 
-type EventType = unknown;
+type EventType = Event["type"];
 
 type tests = [Expect<Equal<EventType, "click" | "focus" | "keydown">>];


### PR DESCRIPTION
## My solution
`
type EventType = Event["type"];
`

## Explanation
By applying indexed access to the union, it will generate every possibility of that key.
All of the union members need to have the `type` key in order for this to work.