### PR TITLE
Solution: 10 As const

### DIFF
--- a/src/02-unions-and-indexing/10-as-const.problem.ts
+++ b/src/02-unions-and-indexing/10-as-const.problem.ts
@@ -11,7 +11,7 @@ export const programModeEnumMap = {
   SELF_DIRECTED: "selfDirected",
   PLANNED_ONE_ON_ONE: "planned1on1",
   PLANNED_SELF_DIRECTED: "plannedSelfDirected",
-};
+} as const;
 
 export type GroupProgram = typeof programModeEnumMap["GROUP"];
 export type AnnouncementProgram = typeof programModeEnumMap["ANNOUNCEMENT"];


### PR DESCRIPTION
## My Solution
Adding as const assertion after the object `programModeEnumMap`

```
export const programModeEnumMap = {
  GROUP: "group",
  ANNOUNCEMENT: "announcement",
  ONE_ON_ONE: "1on1",
  SELF_DIRECTED: "selfDirected",
  PLANNED_ONE_ON_ONE: "planned1on1",
  PLANNED_SELF_DIRECTED: "plannedSelfDirected",
} as const;
```

## Explanation
`As const` assertion asserts that every key in `programModeEnumMap` isn't mutable (read-only), so we could get the literal definition of the object.
