### PR TITLE
Solution: 11 Indexed access with unions

### DIFF
--- a/src/02-unions-and-indexing/11-indexed-access-with-unions.problem.ts
+++ b/src/02-unions-and-indexing/11-indexed-access-with-unions.problem.ts
@@ -10,7 +10,9 @@ export const programModeEnumMap = {
 } as const;
 
 type ProgramModeEnumMap = typeof programModeEnumMap
-export type IndividualProgram = Exclude<ProgramModeEnumMap[keyof ProgramModeEnumMap], "group" | "announcement">;
+type ValueUnion = ProgramModeEnumMap[keyof ProgramModeEnumMap]
+
+export type IndividualProgram = Exclude<ValueUnion, "group" | "announcement">;
 
 type tests = [
   Expect<

--- a/src/02-unions-and-indexing/11-indexed-access-with-unions.problem.ts
+++ b/src/02-unions-and-indexing/11-indexed-access-with-unions.problem.ts
@@ -9,7 +9,8 @@ export const programModeEnumMap = {
   PLANNED_SELF_DIRECTED: "plannedSelfDirected",
 } as const;
 
-export type IndividualProgram = unknown;
+type ProgramModeEnumMap = typeof programModeEnumMap
+export type IndividualProgram = Exclude<ProgramModeEnumMap[keyof ProgramModeEnumMap], "group" | "announcement">;
 
 type tests = [
   Expect<


### PR DESCRIPTION
## My solution
```
type ProgramModeEnumMap = typeof programModeEnumMap
type ValueUnion = ProgramModeEnumMap[keyof ProgramModeEnumMap]

export type IndividualProgram = Exclude<ValueUnion, "group" | "announcement">;
```

## Explanations
As usual, first we need to infer the type from object `programModeEnumMap`. 
The next step we need to generate the union of values.
Finally, we can get rid of the types that we don't want by using `Exclude`