### PR TITLE
Solution: 13 Get array value

### DIFF
--- a/src/02-unions-and-indexing/13-get-array-value.problem.ts
+++ b/src/02-unions-and-indexing/13-get-array-value.problem.ts
@@ -1,9 +1,9 @@
 import { Equal, Expect } from "../helpers/type-utils";
 
-const fruits = ["apple", "banana", "orange"];
+const fruits = ["apple", "banana", "orange"] as const;
 
-type AppleOrBanana = unknown;
-type Fruit = unknown;
+type Fruit = (typeof fruits)[number];
+type AppleOrBanana = Exclude<Fruit, "orange">;
 
 type tests = [
   Expect<Equal<AppleOrBanana, "apple" | "banana">>,


### PR DESCRIPTION
## My solution
```
const fruits = ["apple", "banana", "orange"] as const;

type Fruit = (typeof fruits)[number];
type AppleOrBanana = Exclude<Fruit, "orange">;
```

## Explanation
First we need to declare fruits as const, so we can get the literal value of it.
After that, we can get all the union from array by using syntax (typeof X)[number], indexed access by using type `number`.
For AppleOrBanana, we can generate it from Fruit by excluding "orange".