### PR TITLE
Solution: 14 Template literal with string

### DIFF
--- a/src/03-template-literals/14-template-literal-with-string.problem.ts
+++ b/src/03-template-literals/14-template-literal-with-string.problem.ts
@@ -1,4 +1,4 @@
-type Route = unknown;
+type Route = `/${string}`;
 
 export const goToRoute = (route: Route) => {};
 


### PR DESCRIPTION
## My Solution
```
type Route = `/${string}`;
```

## Explanation
Using literal string `/` to define the mandatory pattern and then followed by optional type `string` after.