### PR TITLE
Solution: 15 Extract with template literals

### DIFF
--- a/src/03-template-literals/15-extract-with-template-literals.problem.ts
+++ b/src/03-template-literals/15-extract-with-template-literals.problem.ts
@@ -2,6 +2,6 @@ import { Equal, Expect } from "../helpers/type-utils";
 
 type Routes = "/users" | "/users/:id" | "/posts" | "/posts/:id";
 
-type DynamicRoutes = unknown;
+type DynamicRoutes = Extract<Routes, `/${string}/:${string}`>;
 
 type tests = [Expect<Equal<DynamicRoutes, "/users/:id" | "/posts/:id">>];


### PR DESCRIPTION
## My solution
```
type DynamicRoutes = Extract<Routes, `/${string}/:${string}`>;
```

## Explanation
In this problem, we utilize the concept of template literal to specify the pattern of dynamic routes.
And then apply that template to the given union. This is kind of using regex but in type domain.