### PR TITLE
Solution: 16 Unions in template literals

### DIFF
--- a/src/03-template-literals/16-unions-in-template-literals.problem.ts
+++ b/src/03-template-literals/16-unions-in-template-literals.problem.ts
@@ -4,7 +4,7 @@ type BreadType = "rye" | "brown" | "white";
 
 type Filling = "cheese" | "ham" | "salami";
 
-type Sandwich = unknown;
+type Sandwich = `${BreadType} sandwich with ${Filling}`;
 
 type tests = [
   Expect<


### PR DESCRIPTION
## My solution
```
type Sandwich = `${BreadType} sandwich with ${Filling}`;
```

## Explanation
By passing unions to template literal, the typescript compiler will do their magic :) 