### PR TITLE
Solution: 17 Splitting strings

### DIFF
--- a/src/03-template-literals/17-splitting-strings.problem.ts
+++ b/src/03-template-literals/17-splitting-strings.problem.ts
@@ -1,13 +1,13 @@
 // Might come in handy!
-// import { S } from "ts-toolbelt";
+import { S } from 'ts-toolbelt'
 // https://millsp.github.io/ts-toolbelt/modules/string_split.html
 
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type Path = "Users/John/Documents/notes.txt";
+type Path = 'Users/John/Documents/notes.txt'
 
-type SplitPath = unknown;
+type SplitPath = S.Split<Path, '/'>
 
 type tests = [
-  Expect<Equal<SplitPath, ["Users", "John", "Documents", "notes.txt"]>>,
-];
+  Expect<Equal<SplitPath, ['Users', 'John', 'Documents', 'notes.txt']>>
+]


### PR DESCRIPTION
## My solution
`type SplitPath = S.Split<Path, '/'>`

## Explanation
Straightforward, call the split utility type and then passed in the Path and character to split (delimiter).