### PR TITLE
Solution: 18 Template literals in object keys

### DIFF
--- a/src/03-template-literals/18-template-literals-in-object-keys.problem.ts
+++ b/src/03-template-literals/18-template-literals-in-object-keys.problem.ts
@@ -1,21 +1,23 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type TemplateLiteralKey = `${"user" | "post" | "comment"}${"Id" | "Name"}`;
+type TemplateLiteralKey = `${'user' | 'post' | 'comment'}${'Id' | 'Name'}`
 
-type ObjectOfKeys = unknown;
+type ObjectOfKeys = {
+  [K in TemplateLiteralKey]: string
+}
 
 type tests = [
   Expect<
     Equal<
       ObjectOfKeys,
       {
-        userId: string;
-        userName: string;
-        postId: string;
-        postName: string;
-        commentId: string;
-        commentName: string;
+        userId: string
+        userName: string
+        postId: string
+        postName: string
+        commentId: string
+        commentName: string
       }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
```
type ObjectOfKeys = {
  [K in TemplateLiteralKey]: string
}
```

## Explanation
Create the object by using indexed access to the template literal union.


## Notes
This solution slightly differs from the course's solution, they propose the cleaner way by utilizing `Record` utility type. For a moment, I forgot that exists :)