### PR TITLE
Solution: 19 Uppercase object

### DIFF
--- a/src/03-template-literals/19-uppercase-object.problem.ts
+++ b/src/03-template-literals/19-uppercase-object.problem.ts
@@ -1,18 +1,18 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type Event = `log_in` | "log_out" | "sign_up";
+type Event = `log_in` | 'log_out' | 'sign_up'
 
-type ObjectOfKeys = unknown;
+type ObjectOfKeys = Record<Uppercase<Event>, string>
 
 type tests = [
   Expect<
     Equal<
       ObjectOfKeys,
       {
-        LOG_IN: string;
-        LOG_OUT: string;
-        SIGN_UP: string;
+        LOG_IN: string
+        LOG_OUT: string
+        SIGN_UP: string
       }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
`type ObjectOfKeys = Record<Uppercase<Event>, string>`

## Explanation
Creating a record of the union of strings, but before assigning each one as key, we transform it to uppercase by using utility type `Uppercase`