### PR TITLE
Solution: 20.2 Constraints

### DIFF
--- a/src/03.5-type-helpers-pattern/20.2-constraints.problem.ts
+++ b/src/03.5-type-helpers-pattern/20.2-constraints.problem.ts
@@ -1,14 +1,14 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type AddRoutePrefix<TRoute> = `/${TRoute}`;
+type AddRoutePrefix<TRoute extends string> = `/${TRoute}`
 
 type tests = [
-  Expect<Equal<AddRoutePrefix<"">, "/">>,
-  Expect<Equal<AddRoutePrefix<"about">, "/about">>,
-  Expect<Equal<AddRoutePrefix<"about/team">, "/about/team">>,
-  Expect<Equal<AddRoutePrefix<"blog">, "/blog">>,
+  Expect<Equal<AddRoutePrefix<''>, '/'>>,
+  Expect<Equal<AddRoutePrefix<'about'>, '/about'>>,
+  Expect<Equal<AddRoutePrefix<'about/team'>, '/about/team'>>,
+  Expect<Equal<AddRoutePrefix<'blog'>, '/blog'>>,
   // @ts-expect-error
   AddRoutePrefix<boolean>,
   // @ts-expect-error
-  AddRoutePrefix<number>,
-];
+  AddRoutePrefix<number>
+]


### PR DESCRIPTION
## My solution
```
type AddRoutePrefix<TRoute extends string> = `/${TRoute}`
```

## Explanation
Using extends to constraint the generic type.