### PR TITLE
Solution: 20.3 Multiple generic

### DIFF
--- a/src/03.5-type-helpers-pattern/20.3-multiple.problem.ts
+++ b/src/03.5-type-helpers-pattern/20.3-multiple.problem.ts
@@ -1,17 +1,17 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type CreateDataShape = {
-  data: unknown;
-  error: unknown;
-};
+type CreateDataShape<T, U> = {
+  data: T
+  error: U
+}
 
 type tests = [
   Expect<
     Equal<
       CreateDataShape<string, TypeError>,
       {
-        data: string;
-        error: TypeError;
+        data: string
+        error: TypeError
       }
     >
   >,
@@ -19,8 +19,8 @@ type tests = [
     Equal<
       CreateDataShape<number, Error>,
       {
-        data: number;
-        error: Error;
+        data: number
+        error: Error
       }
     >
   >,
@@ -28,9 +28,9 @@ type tests = [
     Equal<
       CreateDataShape<boolean, SyntaxError>,
       {
-        data: boolean;
-        error: SyntaxError;
+        data: boolean
+        error: SyntaxError
       }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
```
type CreateDataShape<T, U> = {
  data: T
  error: U
}
```

## Explanation
Grab the type from generic and then populate it to the desired shape.

## Notes
In the actual solution, they use `TData` and `TError`, and I agree it is a better way to name the generic if we use it into object with known keys.