### PR TITLE
Solution: 20.4 Default type for generic

### DIFF
--- a/src/03.5-type-helpers-pattern/20.4-defaults.problem.ts
+++ b/src/03.5-type-helpers-pattern/20.4-defaults.problem.ts
@@ -1,17 +1,17 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type CreateDataShape<TData, TError> = {
-  data: TData;
-  error: TError;
-};
+type CreateDataShape<TData, TError = undefined> = {
+  data: TData
+  error: TError
+}
 
 type tests = [
   Expect<
     Equal<
       CreateDataShape<string>,
       {
-        data: string;
-        error: undefined;
+        data: string
+        error: undefined
       }
     >
   >,
@@ -19,9 +19,9 @@ type tests = [
     Equal<
       CreateDataShape<boolean, SyntaxError>,
       {
-        data: boolean;
-        error: SyntaxError;
+        data: boolean
+        error: SyntaxError
       }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
```
type CreateDataShape<TData, TError = undefined> = {
  data: TData
  error: TError
}
```

## Explanation
Make the type helper to be possible to only accept 1 argument by using default value `undefined` to the second argument.