### PR TITLE
Solution: 20.5 Function contraints

### DIFF
--- a/src/03.5-type-helpers-pattern/20.5-function-constraints.problem.ts
+++ b/src/03.5-type-helpers-pattern/20.5-function-constraints.problem.ts
@@ -1,9 +1,9 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type GetParametersAndReturnType<T> = {
-  params: Parameters<T>;
-  returnValue: ReturnType<T>;
-};
+type GetParametersAndReturnType<T extends (...args: any) => any> = {
+  params: Parameters<T>
+  returnValue: ReturnType<T>
+}
 
 type tests = [
   Expect<
@@ -23,5 +23,5 @@ type tests = [
       GetParametersAndReturnType<(n: number, b: boolean) => number>,
       { params: [number, boolean]; returnValue: number }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
```
type GetParametersAndReturnType<T extends (...args: any) => any> = {
  params: Parameters<T>
  returnValue: ReturnType<T>
}
```

## Explanation
Because of `Parameters` and `ReturnType` require function shape as their argument, 
then we need to constraint our `T` generic to match their required argument.
In this case, I put `(...args: any) => any` as the constraint (function with multiple any argument and an any return), matched to the error given by Typescript compiler.