### PR TITLE
Solution: 20.6 Not null or undefined constraint

### DIFF
--- a/src/03.5-type-helpers-pattern/20.6-not-undefined-or-null-constraint.problem.ts
+++ b/src/03.5-type-helpers-pattern/20.6-not-undefined-or-null-constraint.problem.ts
@@ -1,4 +1,12 @@
-export type Maybe<T> = T | null | undefined;
+export type Maybe<T extends Exclude<any, null | undefined>> =
+  | T
+  | null
+  | undefined
+
+// I thought any = number | string | bigint | boolean | .... | null | undefined
+// So if I exclude null | undefined, I expect it will return number | string | bigint | boolean | .... | never | never
+// Turns out, it still returns any
+type Example = Exclude<unknown, null | undefined>
 
 type tests = [
   // @ts-expect-error
@@ -9,5 +17,5 @@ type tests = [
   Maybe<string>,
   Maybe<false>,
   Maybe<0>,
-  Maybe<"">,
-];
+  Maybe<''>
+]


### PR DESCRIPTION
## My solution
```
export type Maybe<T extends Exclude<any, null | undefined>> =
  | T
  | null
  | undefined
```


## Explanation
This solution of mine isn't correct 😢 .

`type Example = Exclude<unknown, null | undefined>`

I thought `any = number | string | bigint | boolean | .... | null | undefined`
So if I exclude `null | undefined`, I expect it will return `number | string | bigint | boolean | .... | never | never`
Turns out, it still returns any.

## Notes
The correct solution
```
export type Maybe<T extends {}> =
  | T
  | null
  | undefined
```

Because every type in typescript is basically `object`, like string is an object with methods attached to it, array is object too, etc.