### PR TITLE
Solution: 20.7 Non empty array

### DIFF
--- a/src/03.5-type-helpers-pattern/20.7-non-empty-array.problem.ts
+++ b/src/03.5-type-helpers-pattern/20.7-non-empty-array.problem.ts
@@ -1,9 +1,9 @@
-type NonEmptyArray = unknown;
+type NonEmptyArray<T> = [T, ...T[]]
 
-export const makeEnum = (values: NonEmptyArray<string>) => {};
+export const makeEnum = (values: NonEmptyArray<string>) => {}
 
-makeEnum(["a"]);
-makeEnum(["a", "b", "c"]);
+makeEnum(['a'])
+makeEnum(['a', 'b', 'c'])
 
 // @ts-expect-error
-makeEnum([]);
+makeEnum([])


### PR DESCRIPTION
## My solution
`type NonEmptyArray<T> = [T, ...T[]]`

## Explanation
We define a tuple, where we specify the first element must exist and then use rest operator to allow any kind of length.