### PR TITLE
Solution: 22 Returning never

### DIFF
--- a/src/04-conditional-types-and-infer/22-returning-never.problem.ts
+++ b/src/04-conditional-types-and-infer/22-returning-never.problem.ts
@@ -1,10 +1,14 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type YouSayGoodbyeAndISayHello<T> = T extends "hello" ? "goodbye" : "hello";
+type YouSayGoodbyeAndISayHello<T> = T extends 'hello'
+  ? 'goodbye'
+  : T extends 'goodbye'
+  ? 'hello'
+  : never
 
 type tests = [
-  Expect<Equal<YouSayGoodbyeAndISayHello<"hello">, "goodbye">>,
-  Expect<Equal<YouSayGoodbyeAndISayHello<"goodbye">, "hello">>,
-  Expect<Equal<YouSayGoodbyeAndISayHello<"alright pal">, never>>,
-  Expect<Equal<YouSayGoodbyeAndISayHello<1>, never>>,
-];
+  Expect<Equal<YouSayGoodbyeAndISayHello<'hello'>, 'goodbye'>>,
+  Expect<Equal<YouSayGoodbyeAndISayHello<'goodbye'>, 'hello'>>,
+  Expect<Equal<YouSayGoodbyeAndISayHello<'alright pal'>, never>>,
+  Expect<Equal<YouSayGoodbyeAndISayHello<1>, never>>
+]


### PR DESCRIPTION
## My Solution
```
type YouSayGoodbyeAndISayHello<T> = T extends 'hello'
  ? 'goodbye'
  : T extends 'goodbye'
  ? 'hello'
  : never

```
## Explanation
Using ternary to perform type checking and return appropriate type response based on the condition.

## Notes
In the actual solution, it is slightly different. But still it solves the same problem.
```
type YouSayGoodbyeAndISayHello<T> = T extends "hello" | "goodbye"
  ? T extends "hello"
    ? "goodbye"
    : "hello"
  : never;
```
