### PR TITLE
Solution: 23 Infer with raw values

### DIFF
--- a/src/04-conditional-types-and-infer/23-infer-with-raw-values.problem.ts
+++ b/src/04-conditional-types-and-infer/23-infer-with-raw-values.problem.ts
@@ -1,17 +1,17 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type GetDataValue<T> = unknown;
+type GetDataValue<T> = T extends { data: infer K } ? K : never
 
 type tests = [
-  Expect<Equal<GetDataValue<{ data: "hello" }>, "hello">>,
-  Expect<Equal<GetDataValue<{ data: { name: "hello" } }>, { name: "hello" }>>,
+  Expect<Equal<GetDataValue<{ data: 'hello' }>, 'hello'>>,
+  Expect<Equal<GetDataValue<{ data: { name: 'hello' } }>, { name: 'hello' }>>,
   Expect<
     Equal<
-      GetDataValue<{ data: { name: "hello"; age: 20 } }>,
-      { name: "hello"; age: 20 }
+      GetDataValue<{ data: { name: 'hello'; age: 20 } }>,
+      { name: 'hello'; age: 20 }
     >
   >,
   // Expect that if you pass in string, it
   // should return never
-  Expect<Equal<GetDataValue<string>, never>>,
-];
+  Expect<Equal<GetDataValue<string>, never>>
+]


### PR DESCRIPTION
## My solution
`type GetDataValue<T> = T extends { data: infer K } ? K : never`

## Explanation
Infer the type of data value and then return that inferred type

## Notes
Inferred type only can be accessed via true branch