### PR TITLE
Solution: 24 Infer with generics

### DIFF
--- a/src/04-conditional-types-and-infer/24-infer-with-generics.problem.ts
+++ b/src/04-conditional-types-and-infer/24-infer-with-generics.problem.ts
@@ -1,19 +1,19 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 interface MyComplexInterface<Event, Context, Name, Point> {
-  getEvent: () => Event;
-  getContext: () => Context;
-  getName: () => Name;
-  getPoint: () => Point;
+  getEvent: () => Event
+  getContext: () => Context
+  getName: () => Name
+  getPoint: () => Point
 }
 
 type Example = MyComplexInterface<
-  "click",
-  "window",
-  "my-event",
+  'click',
+  'window',
+  'my-event',
   { x: 12; y: 14 }
->;
+>
 
-type GetPoint<T> = unknown;
+type GetPoint<T> = T extends { getPoint: () => infer Point } ? Point : never
 
-type tests = [Expect<Equal<GetPoint<Example>, { x: 12; y: 14 }>>];
+type tests = [Expect<Equal<GetPoint<Example>, { x: 12; y: 14 }>>]


### PR DESCRIPTION
## My Solution
`type GetPoint<T> = T extends { getPoint: () => infer Point } ? Point : never`

## Explanation
Firstly, we define the type of the desired T shape, which has `getPoint` method.
After that, we infer the return type from `getPoint` method.

## Notes
Oops, I understood this incorrectly.
I should solve it by using type inference of the interface generic declaration.
So it should be like this.

```
type GetPoint<T> = T extends MyComplexInterface<any, any, any, infer TPoint>
  ? TPoint
  : never;
```

The benefit of using this approach. we don't get tied to the internal declaration of `GetPoint`