### PR TITLE
Solution 25: Template literal value extraction

### DIFF
--- a/src/04-conditional-types-and-infer/25-template-literal-value-extraction.problem.ts
+++ b/src/04-conditional-types-and-infer/25-template-literal-value-extraction.problem.ts
@@ -1,19 +1,19 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 type Names = [
-  "Matt Pocock",
-  "Jimi Hendrix",
-  "Eric Clapton",
-  "John Mayer",
-  "BB King",
-];
+  'Matt Pocock',
+  'Jimi Hendrix',
+  'Eric Clapton',
+  'John Mayer',
+  'BB King'
+]
 
-type GetSurname<T> = unknown;
+type GetSurname<T> = T extends `${string} ${infer TSurname}` ? TSurname : never
 
 type tests = [
-  Expect<Equal<GetSurname<Names[0]>, "Pocock">>,
-  Expect<Equal<GetSurname<Names[1]>, "Hendrix">>,
-  Expect<Equal<GetSurname<Names[2]>, "Clapton">>,
-  Expect<Equal<GetSurname<Names[3]>, "Mayer">>,
-  Expect<Equal<GetSurname<Names[4]>, "King">>,
-];
+  Expect<Equal<GetSurname<Names[0]>, 'Pocock'>>,
+  Expect<Equal<GetSurname<Names[1]>, 'Hendrix'>>,
+  Expect<Equal<GetSurname<Names[2]>, 'Clapton'>>,
+  Expect<Equal<GetSurname<Names[3]>, 'Mayer'>>,
+  Expect<Equal<GetSurname<Names[4]>, 'King'>>
+]


### PR DESCRIPTION
## My solution
`type GetSurname<T> = T extends `${string} ${infer TSurname}` ? TSurname : never`

## Explanation
So first we need to define the pattern of type literal (with space in the middle), and then after we can infer and return the last piece of the string.