### PR TITLE
Solution: 26 Get result from async function

### DIFF
--- a/src/04-conditional-types-and-infer/26-get-result-from-async-function.problem.ts
+++ b/src/04-conditional-types-and-infer/26-get-result-from-async-function.problem.ts
@@ -1,16 +1,20 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 const getServerSideProps = async () => {
-  const data = await fetch("https://jsonplaceholder.typicode.com/todos/1");
-  const json: { title: string } = await data.json();
+  const data = await fetch('https://jsonplaceholder.typicode.com/todos/1')
+  const json: { title: string } = await data.json()
   return {
     props: {
       json,
     },
-  };
-};
+  }
+}
 
-type InferPropsFromServerSideFunction = unknown;
+type InferPropsFromServerSideFunction<T> = T extends () => Promise<{
+  props: infer TProps
+}>
+  ? TProps
+  : never
 
 type tests = [
   Expect<
@@ -19,4 +23,4 @@ type tests = [
       { json: { title: string } }
     >
   >
-];
+]


### PR DESCRIPTION
## My solution
```
type InferPropsFromServerSideFunction<T> = T extends () => Promise<{
  props: infer TProps
}>
  ? TProps
  : never
```

## Explanation
First, specify the shape of true branch, which is Promise that return object with key `props`.
From that shape, we capture the type of `props` with infer.