### PR TITLE
Solution: 27 Infer in union types

### DIFF
--- a/src/04-conditional-types-and-infer/27-infer-in-union-types.problem.ts
+++ b/src/04-conditional-types-and-infer/27-infer-in-union-types.problem.ts
@@ -1,19 +1,24 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 const parser1 = {
   parse: () => 1,
-};
+}
 
-const parser2 = () => "123";
+const parser2 = () => '123'
 
 const parser3 = {
   extract: () => true,
-};
+}
 
-type GetParserResult<T> = unknown;
+type GetParserResult<T> = T extends
+  | { parse: () => infer P }
+  | (() => infer P)
+  | { extract: () => infer P }
+  ? P
+  : never
 
 type tests = [
   Expect<Equal<GetParserResult<typeof parser1>, number>>,
   Expect<Equal<GetParserResult<typeof parser2>, string>>,
-  Expect<Equal<GetParserResult<typeof parser3>, boolean>>,
-];
+  Expect<Equal<GetParserResult<typeof parser3>, boolean>>
+]


### PR DESCRIPTION
## My solution
```
type GetParserResult<T> = T extends
  | { parse: () => infer P }
  | (() => infer P)
  | { extract: () => infer P }
  ? P
  : never
```

## Explanation
By using conditional types, we need to define the possibility of the parser input shapes.
In this case, we need to define 3 different shapes and infer the return type at respective positions.