### PR TITLE
Solution: 28 Distributive conditional types

### DIFF
--- a/src/04-conditional-types-and-infer/28-distributive-conditional-types.problem.ts
+++ b/src/04-conditional-types-and-infer/28-distributive-conditional-types.problem.ts
@@ -1,7 +1,10 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type Fruit = "apple" | "banana" | "orange";
+type Fruit = 'apple' | 'banana' | 'orange'
 
-type AppleOrBanana = Fruit extends "apple" | "banana" ? Fruit : never;
+type AppleOrBanana1 = Fruit extends 'apple' | 'banana' ? Fruit : never
 
-type tests = [Expect<Equal<AppleOrBanana, "apple" | "banana">>];
+type GetAppleOrBanana<T> = T extends 'apple' | 'banana' ? T : never
+type AppleOrBanana = GetAppleOrBanana<Fruit>
+
+type tests = [Expect<Equal<AppleOrBanana, 'apple' | 'banana'>>]


### PR DESCRIPTION
## My solution
```
type AppleOrBanana1 = Fruit extends 'apple' | 'banana' ? Fruit : never // the intial type declaration

type GetAppleOrBanana<T> = T extends 'apple' | 'banana' ? T : never
type AppleOrBanana = GetAppleOrBanana<Fruit>
```

## Explanation
This problem emphasizes distributive characteristic of conditional types that only work for generics.
So if we're not using generic, it will capture Fruit as a whole `'apple' | 'banana' | 'orange'` which doesn't extends `apple' | 'banana'`.

But if we alias it to generic first it will make it distributive. So we get the process like this:
`('apple' extends 'apple' | 'banana') | ('banana' extends  'apple' | 'banana') | ('orange' extends 'apple' | 'banana').`

So in the end, we end up with `
'apple' | 'banana' | never -> 'apple' | 'banana'`