### PR TITLE
Solution: 29 Union to object

### DIFF
--- a/src/05-key-remapping/29-union-to-object.problem.ts
+++ b/src/05-key-remapping/29-union-to-object.problem.ts
@@ -1,19 +1,21 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type Route = "/" | "/about" | "/admin" | "/admin/users";
+type Route = '/' | '/about' | '/admin' | '/admin/users'
 
-type RoutesObject = unknown;
+type RoutesObject = {
+  [K in Route]: K
+}
 
 type tests = [
   Expect<
     Equal<
       RoutesObject,
       {
-        "/": "/";
-        "/about": "/about";
-        "/admin": "/admin";
-        "/admin/users": "/admin/users";
+        '/': '/'
+        '/about': '/about'
+        '/admin': '/admin'
+        '/admin/users': '/admin/users'
       }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
```
type Route = '/' | '/about' | '/admin' | '/admin/users'

type RoutesObject = {
  [K in Route]: K
}
```

## Explanation
In this case, we iterate over the union using mapped type by using `in` keyword.

## Notes
Matt explains by the detailed explanation,
`For each member of the Route union, extract our K into a private variable, into something that we can access here, and add it as the value.`