### PR TITLE
Solution: 30 K in keyof problem

### DIFF
--- a/src/05-key-remapping/30-k-in-keyof.problem.ts
+++ b/src/05-key-remapping/30-k-in-keyof.problem.ts
@@ -1,22 +1,24 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 interface Attributes {
-  firstName: string;
-  lastName: string;
-  age: number;
+  firstName: string
+  lastName: string
+  age: number
 }
 
-type AttributeGetters = unknown;
+type AttributeGetters = {
+  [K in keyof Attributes]: () => Attributes[K]
+}
 
 type tests = [
   Expect<
     Equal<
       AttributeGetters,
       {
-        firstName: () => string;
-        lastName: () => string;
-        age: () => number;
+        firstName: () => string
+        lastName: () => string
+        age: () => number
       }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
```
type AttributeGetters = {
  [K in keyof Attributes]: () => Attributes[K]
}
```

## Explanation
The solution is to get the union of Attributes by using `keyof Attributes`. 
And then we need to map over that keys union.

While mapping the keys, we get access to each key via generic `K`. 
With that generic, we can apply indexed access concept to define the return value.