### PR TITLE
Solution: 31 K in keyof as problem

### DIFF
--- a/src/05-key-remapping/31-k-in-keyof-as.problem.ts
+++ b/src/05-key-remapping/31-k-in-keyof-as.problem.ts
@@ -1,24 +1,24 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 interface Attributes {
-  firstName: string;
-  lastName: string;
-  age: number;
+  firstName: string
+  lastName: string
+  age: number
 }
 
 type AttributeGetters = {
-  [K in keyof Attributes]: () => Attributes[K];
-};
+  [K in keyof Attributes as `get${Capitalize<K>}`]: () => Attributes[K]
+}
 
 type tests = [
   Expect<
     Equal<
       AttributeGetters,
       {
-        getFirstName: () => string;
-        getLastName: () => string;
-        getAge: () => number;
+        getFirstName: () => string
+        getLastName: () => string
+        getAge: () => number
       }
     >
   >
-];
+]


### PR DESCRIPTION
## My solution
```
type AttributeGetters = {
  [K in keyof Attributes as `get${Capitalize<K>}`]: () => Attributes[K]
}
```

## Explanation
Using `as` to remap each key to an alias name, in this case the alias name is `get....`