### PR TITLE
Solution: 32 Never in key remapping

### DIFF
--- a/src/05-key-remapping/32-never-in-key-remapping.problem.ts
+++ b/src/05-key-remapping/32-never-in-key-remapping.problem.ts
@@ -1,25 +1,29 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 interface Example {
-  name: string;
-  age: number;
-  id: string;
-  organisationId: string;
-  groupId: string;
+  name: string
+  age: number
+  id: string
+  organisationId: string
+  groupId: string
 }
 
-type OnlyIdKeys<T> = unknown;
+type OnlyIdKeys<T> = {
+  [K in keyof T as K extends `${string}Id` | 'id' ? K : never]: T[K]
+}
+
+type Test = OnlyIdKeys<Example>
 
 type tests = [
   Expect<
     Equal<
       OnlyIdKeys<Example>,
       {
-        id: string;
-        organisationId: string;
-        groupId: string;
+        id: string
+        organisationId: string
+        groupId: string
       }
     >
   >,
   Expect<Equal<OnlyIdKeys<{}>, {}>>
-];
+]


### PR DESCRIPTION
## My solution
```
type OnlyIdKeys<T> = {
  [K in keyof T as K extends `${string}Id` | 'id' ? K : never]: T[K]
}
```

## Explanation
We can add a conditional type when remapping each key, to filter out the key without string `id`,
The condition for the `true` branch is by returning the key `K` as is, while if `false` we need to return `never`.
By returning `never`, the end result will generate an object without that key.