### PR TITLE
Solution: 33 Discriminated union to object

### DIFF
--- a/src/05-key-remapping/33-discriminated-union-to-object.problem.ts
+++ b/src/05-key-remapping/33-discriminated-union-to-object.problem.ts
@@ -1,32 +1,34 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 type Route =
   | {
-      route: "/";
+      route: '/'
       search: {
-        page: string;
-        perPage: string;
-      };
+        page: string
+        perPage: string
+      }
     }
-  | { route: "/about"; search: {} }
-  | { route: "/admin"; search: {} }
-  | { route: "/admin/users"; search: {} };
+  | { route: '/about'; search: {} }
+  | { route: '/admin'; search: {} }
+  | { route: '/admin/users'; search: {} }
 
-type RoutesObject = unknown;
+type RoutesObject = {
+  [K in Route['route']]: Extract<Route, { route: K }>['search']
+}
 
 type tests = [
   Expect<
     Equal<
       RoutesObject,
       {
-        "/": {
-          page: string;
-          perPage: string;
-        };
-        "/about": {};
-        "/admin": {};
-        "/admin/users": {};
+        '/': {
+          page: string
+          perPage: string
+        }
+        '/about': {}
+        '/admin': {}
+        '/admin/users': {}
       }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
```
type RoutesObject = {
  [K in Route['route']]: Extract<Route, { route: K }>['search']
}
```

## Explanation
First step, we need to iterate over the indexed access of union Route["route"]:
`[K in Route["route"]] <-> [K in "/" | "/about" | "/admin" | "/admin/users"]`

The next step, we can using extract to extract a value from discriminated union by using the generic `K`
`Extract<Route, { route: K }>`

Last, using indexed access to 'search' key to map them over.

## Notes
The solution above is too verbose.
Matt explains a better solution by using key remapping `as` 👍 

```
type RoutesObject = {
  [R in Route as R["route"]]: R["search"]
}
```

In this case, we iterate over the discriminated union member itself, instead of the discriminator.
This is absolutely beautiful!
