### PR TITLE
Solution: 34 Object to union of tuples

### DIFF
--- a/src/05-key-remapping/34-object-to-union-of-tuples.problem.ts
+++ b/src/05-key-remapping/34-object-to-union-of-tuples.problem.ts
@@ -1,20 +1,20 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 interface Values {
-  email: string;
-  firstName: string;
-  lastName: string;
+  email: string
+  firstName: string
+  lastName: string
 }
 
 type ValuesAsUnionOfTuples = {
-  [K in keyof Values]: [K, Values[K]];
-};
+  [K in keyof Values]: [K, Values[K]]
+}[keyof Values]
 
 type tests = [
   Expect<
     Equal<
       ValuesAsUnionOfTuples,
-      ["email", string] | ["firstName", string] | ["lastName", string]
+      ['email', string] | ['firstName', string] | ['lastName', string]
     >
   >
-];
+]


### PR DESCRIPTION
## My solution
```
type ValuesAsUnionOfTuples = {
  [K in keyof Values]: [K, Values[K]]
}[keyof Values]
```

## Explanation
From the resulting object, to generate union we use indexed access to iterate over each key of the object type

## Notes
From the course, Matt explains we generate intermediary values
```
type ValuesAsUnionOfTuples = {
  [K in keyof Values]: [K, Values[K]]
}
```
before generating the union of tuples