### PR TITLE
Solution: 35 Object to union of template literals

### DIFF
--- a/src/05-key-remapping/35-object-to-union-of-template-literals.problem.ts
+++ b/src/05-key-remapping/35-object-to-union-of-template-literals.problem.ts
@@ -1,15 +1,17 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 interface FruitMap {
-  apple: "red";
-  banana: "yellow";
-  orange: "orange";
+  apple: 'red'
+  banana: 'yellow'
+  orange: 'orange'
 }
 
-type TransformedFruit = unknown;
+type TransformedFruit = {
+  [K in keyof FruitMap]: `${K}:${FruitMap[K]}`
+}[keyof FruitMap]
 
 type tests = [
   Expect<
-    Equal<TransformedFruit, "apple:red" | "banana:yellow" | "orange:orange">
-  >,
-];
+    Equal<TransformedFruit, 'apple:red' | 'banana:yellow' | 'orange:orange'>
+  >
+]


### PR DESCRIPTION
## My solution
```
type TransformedFruit = {
  [K in keyof FruitMap]: `${K}:${FruitMap[K]}`
}[keyof FruitMap]
```

## Explanation
In this case, we map over each key of `Fruitmap` to the intermediary value which contain pair of key and template literal as the value.
From there, we can use indexed access to generate union of the template literal.