### PR TITLE
Solution: 36 Discriminated union to union

### DIFF
--- a/src/05-key-remapping/36-discriminated-union-to-union.problem.ts
+++ b/src/05-key-remapping/36-discriminated-union-to-union.problem.ts
@@ -1,23 +1,25 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 type Fruit =
   | {
-      name: "apple";
-      color: "red";
+      name: 'apple'
+      color: 'red'
     }
   | {
-      name: "banana";
-      color: "yellow";
+      name: 'banana'
+      color: 'yellow'
     }
   | {
-      name: "orange";
-      color: "orange";
-    };
+      name: 'orange'
+      color: 'orange'
+    }
 
-type TransformedFruit = unknown;
+type TransformedFruit = {
+  [F in Fruit as F['name']]: `${F['name']}:${F['color']}`
+}[Fruit['name']]
 
 type tests = [
   Expect<
-    Equal<TransformedFruit, "apple:red" | "banana:yellow" | "orange:orange">
-  >,
-];
+    Equal<TransformedFruit, 'apple:red' | 'banana:yellow' | 'orange:orange'>
+  >
+]


### PR DESCRIPTION
## My solution
```
type TransformedFruit = {
  [F in Fruit as F['name']]: `${F['name']}:${F['color']}`
}[Fruit['name']]
```

## Explanation
This is kind of hard to read LOL.
But let me explain it piece by piece.

First piece of the code, we can get the access to each member of discriminated union by using `F in Fruit`
```
type TransformedFruit = {
  [F in Fruit as F['name']]: string
}
```
But we need to remember, that we can't use object as the key of the object type. 
So, we need to remap the by a piece of string, in this case we use `F["name"]`, the indexed access `name` of each union member.

After that, instead of string, we change it to the desired template literal.
```
type TransformedFruit = {
  [F in Fruit as F['name']]: `${F['name']}:${F['color']}`
}
```

Great, here we can look here we have access over both of `name` and `color`.
Lastly, we can apply indexed access using union of name from `Fruit`.

```
type TransformedFruit = {
  [F in Fruit as F['name']]: `${F['name']}:${F['color']}`
}[Fruit['name']]

```

