### PR TITLE
Solution: 37 Get dynamic path params

### DIFF
--- a/src/06-challenges/37-get-dynamic-path-params.problem.ts
+++ b/src/06-challenges/37-get-dynamic-path-params.problem.ts
@@ -1,10 +1,23 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { S, T } from 'ts-toolbelt'
+import { Equal, Expect } from '../helpers/type-utils'
 
-type UserPath = "/users/:id";
+type UserPath = '/users/:id'
 
-type UserOrganisationPath = "/users/:id/organisations/:organisationId";
+type UserOrganisationPath = '/users/:id/organisations/:organisationId'
 
-type ExtractPathParams = unknown;
+type ExtractPathParams<T extends string> = {
+  [K in S.Split<T, '/'>[number] as K extends `:${infer Path}`
+    ? Path
+    : never]: string
+}
+
+/* If want to create ExtractPathParams with union as the solution */
+type ExtractPathParams2<T extends string> =
+  T extends `${string}/:${infer Param}/${infer Rest}`
+    ? Param | ExtractPathParams2<Rest>
+    : T extends `${string}/:${infer Param}`
+    ? Param
+    : never
 
 type tests = [
   Expect<Equal<ExtractPathParams<UserPath>, { id: string }>>,
@@ -13,5 +26,5 @@ type tests = [
       ExtractPathParams<UserOrganisationPath>,
       { id: string; organisationId: string }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
```
type ExtractPathParams<T extends string> = {
  [K in S.Split<T, '/'>[number] as K extends `:${infer Path}`
    ? Path
    : never]: string
}
```

## Explanation
First step, we need to understand this piece of code:

```
type ExtractPathParams<T extends string> = {
  [K in S.Split<T, '/'>[number]]: string
}
```

This will create the result as 
```
{
	"": string,
	"users": string,
	":id": string
}
```

From there we need to think how to filter the undesired params, we can do that by using key remapping.
If K doesn't satisfy this pattern  `:${infer Path}` , we can return never to filter it out.