### PR TITLE
Solution: 38 Mutually exclusive properties problem

### DIFF
--- a/src/06-challenges/38-mutually-exclusive-properties.problem.ts
+++ b/src/06-challenges/38-mutually-exclusive-properties.problem.ts
@@ -1,32 +1,36 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 interface Attributes {
-  id: string;
-  email: string;
-  username: string;
+  id: string
+  email: string
+  username: string
 }
 
 /**
  * How do we create a type helper that represents a union
  * of all possible combinations of Attributes?
  */
-type MutuallyExclusive<T> = unknown;
+type MutuallyExclusive<T> = {
+  [K in keyof T]: {
+    [P in K]: T[K]
+  }
+}[keyof T]
 
-type ExclusiveAttributes = MutuallyExclusive<Attributes>;
+type ExclusiveAttributes = MutuallyExclusive<Attributes>
 
 type tests = [
   Expect<
     Equal<
       ExclusiveAttributes,
       | {
-          id: string;
+          id: string
         }
       | {
-          email: string;
+          email: string
         }
       | {
-          username: string;
+          username: string
         }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
```
type MutuallyExclusive<T> = {
  [K in keyof T]: {
    [P in K]: T[K]
  }
}[keyof T]
```

## Explanation
So first, we have to do this step 
```
{
  [K in keyof T]: {
    [P in K]: T[K]
  }
}
```

This will create an object type like this:
```
type ExclusiveAttributes = {
    id: {
        id: string;
    };
    email: {
        email: string;
    };
    username: {
        username: string;
    };
}
```

Aha, we can see we get the component that we want, now we can do iteration over the key of this object by using [keyof T].
So the final implementation will look like this:
```
type MutuallyExclusive<T> = {
  [K in keyof T]: {
    [P in K]: T[K]
  }
}[keyof T]
```


## Notes
This might be the expected behavior from TS, but for some reason I can't use this syntax 
```
{
  [K in keyof T]: {
    [K]: T[K]
  }
}
```

The [K] syntax will return error:
```
A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type.
'K' only refers to a type, but is being used as a value here.
```