### PR TITLE
Solution: 39 Discriminated union with unique values to object

### DIFF
--- a/src/06-challenges/39-discriminated-union-with-unique-values-to-object.problem.ts
+++ b/src/06-challenges/39-discriminated-union-with-unique-values-to-object.problem.ts
@@ -1,32 +1,41 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 type Route =
   | {
-      route: "/";
+      route: '/'
       search: {
-        page: string;
-        perPage: string;
-      };
+        page: string
+        perPage: string
+      }
     }
-  | { route: "/about" }
-  | { route: "/admin" }
-  | { route: "/admin/users" };
+  | { route: '/about' }
+  | { route: '/admin' }
+  | { route: '/admin/users' }
 
-type RoutesObject = unknown;
+// This solution will return this error
+// Type '"search"' cannot be used to index type 'K'
+// I guess it is because the the TS compiler can't detect whether "search" key will exist in the K until runtime
+type RoutesObject2 = {
+  [K in Route as K['route']]: K['search'] extends object ? K['search'] : never
+}
+
+type RoutesObject = {
+  [K in Route as K['route']]: 'search' extends keyof K ? K['search'] : never
+}
 
 type tests = [
   Expect<
     Equal<
       RoutesObject,
       {
-        "/": {
-          page: string;
-          perPage: string;
-        };
-        "/about": never;
-        "/admin": never;
-        "/admin/users": never;
+        '/': {
+          page: string
+          perPage: string
+        }
+        '/about': never
+        '/admin': never
+        '/admin/users': never
       }
     >
-  >,
-];
+  >
+]


### PR DESCRIPTION
## My solution
```
type RoutesObject = {
  [K in Route as K['route']]: 'search' extends keyof K ? K['search'] : never
}
```

## Explanation
First we need to iterate over the union member
```
type RoutesObject = {
  [K in Route]: ...
}
```

But since the Route will produce an object and not literal value `number` or `string`, the TS compiler will return error. To handle this problem, we need to alias over the keys
```
type RoutesObject = {
  [K in Route as Route["route"]]: ...
}
```

After this we can proceed to the value of the object. My initial solution looks like this:
```
type RoutesObject2 = {
  [K in Route as K['route']]: K['search'] extends object ? K['search'] : never
}
```
But since TS compiler can't detect whether "search" key will exist in the K or not until runtime, we can't do this.

After asking chatGPT, I got a pretty good solution. So we can do conditional checking by making sure if key `search` exists in K.
```
type RoutesObject = {
  [K in Route as K['route']]: 'search' extends keyof K ? K['search'] : never
}
```


## Notes
Matt came up with a cleaner solution by using the help of `infer`
```
type RoutesObject = {
  [R in Route as R["route"]]: R extends { search: infer S } ? S : never;
};
```
I like this solution because it tells us more obviously about what we are doing.