### PR TITLE
Solution: 40 Deep Partial

### DIFF
--- a/src/06-challenges/40-deep-partial.problem.ts
+++ b/src/06-challenges/40-deep-partial.problem.ts
@@ -1,42 +1,44 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-type DeepPartial<T> = unknown;
+type DeepPartial<T> = T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : { [K in keyof T]?: DeepPartial<T[K]> }
 
 type MyType = {
-  a: string;
-  b: number;
+  a: string
+  b: number
   c: {
-    d: string;
+    d: string
     e: {
-      f: string;
+      f: string
       g: {
-        h: string;
-        i: string;
-      }[];
-    };
-  };
-};
+        h: string
+        i: string
+      }[]
+    }
+  }
+}
 
-type Result = DeepPartial<MyType>;
+type Result = DeepPartial<MyType>
 
 type tests = [
   Expect<
     Equal<
       Result,
       {
-        a?: string;
-        b?: number;
+        a?: string
+        b?: number
         c?: {
-          d?: string;
+          d?: string
           e?: {
-            f?: string;
+            f?: string
             g?: {
-              h?: string;
-              i?: string;
-            }[];
-          };
-        };
+              h?: string
+              i?: string
+            }[]
+          }
+        }
       }
     >
   >
-];
+]


### PR DESCRIPTION
## My solution
I didn't come up with the solution :) becasuse this requires a really deep knowledge of typescript.
So in the end, I look at Matt's solution

```
type DeepPartial<T> = T extends Array<infer U>
  ? Array<DeepPartial<U>>
  : { [K in keyof T]?: DeepPartial<T[K]> };
```

## Explanation
My initial solution only came up until this line. Where we have to use recursive `DeepPartial`.
`type DeepPartial<T> = { [K in keyof T]?: DeepPartial<T[K]> };`

From this point I don't know what's wrong and what should I do. But Matt explained it well that when we don't handle the array, we can push arbitrary `undefined` value for example to `g`.
So we have to handle it specifically for array, where we have to infer the type of array member and do the DeepPartial to the array member, instead of to the whole Array